### PR TITLE
URL Cleanup

### DIFF
--- a/docs/go.adoc
+++ b/docs/go.adoc
@@ -133,7 +133,7 @@ $ govendor test +local
 ----
 
 Tests are written using the link:https://onsi.github.io/ginkgo/[Ginkgo] BDD testing framework
-and the link:http://onsi.github.io/gomega/[Gomega] matcher library, which are included in the `/vendor`
+and the link:https://onsi.github.io/gomega/[Gomega] matcher library, which are included in the `/vendor`
 directory.
 
 To run tests using Ginkgo, install the executable as follows (unless you did that already):

--- a/download/cache/cache_test.go
+++ b/download/cache/cache_test.go
@@ -43,7 +43,7 @@ const (
 	cfHomeProperty = "CF_HOME"
 	homeProperty   = "HOME"
 	errMessage     = "worse things happen at sea"
-	urlValue       = "http://host/path/file.extension"
+	urlValue       = "https://host/path/file.extension"
 )
 
 var (

--- a/download/cache/etag_index_test.go
+++ b/download/cache/etag_index_test.go
@@ -13,8 +13,8 @@ import (
 
 var _ = Describe("EtagIndex", func() {
 	const (
-		url1  = "http://url.1"
-		url2  = "http://url.2"
+		url1  = "https://url.1"
+		url2  = "https://url.2"
 		etag1 = "etag1"
 		etag2 = "etag2"
 	)

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -42,7 +42,7 @@ const (
 	ifNoneMatchHeader = "If-None-Match"
 	etagHeader        = "ETag"
 	etagValue         = "etag"
-	urlValue          = "http://some/remote/file"
+	urlValue          = "https://some/remote/file"
 	checksumValue     = "checksum"
 	testFilePath      = "/some/path"
 )
@@ -129,7 +129,7 @@ var _ = Describe("Download", func() {
 					})
 
 					It("should propagate the error", func() {
-						Expect(err).To(MatchError(fmt.Sprintf(`CreateHttpRequest for download URL "http://some/remote/file" failed: %s`, errMessage)))
+						Expect(err).To(MatchError(fmt.Sprintf(`CreateHttpRequest for download URL "https://some/remote/file" failed: %s`, errMessage)))
 					})
 				})
 
@@ -190,7 +190,7 @@ var _ = Describe("Download", func() {
 					})
 
 					It("should propagate the error", func() {
-						Expect(err).To(MatchError(fmt.Sprintf(`Download from URL "http://some/remote/file" failed: %s`, errMessage)))
+						Expect(err).To(MatchError(fmt.Sprintf(`Download from URL "https://some/remote/file" failed: %s`, errMessage)))
 					})
 				})
 
@@ -435,7 +435,7 @@ var _ = Describe("HttpResponse", func() {
 
 var _ = Describe("CreateHttpRequest", func() {
 	It("should return a suitable error when the method is unknown", func() {
-		_, err := download.NewHttpHelper().CreateHttpRequest("bad method", "http://example.com")
+		_, err := download.NewHttpHelper().CreateHttpRequest("bad method", "https://example.com")
 		Expect(err).To(MatchError(`net/http: invalid method "bad method"`))
 	})
 })

--- a/vendor/github.com/fatih/color/README.md
+++ b/vendor/github.com/fatih/color/README.md
@@ -3,7 +3,7 @@
 
 
 Color lets you use colorized outputs in terms of [ANSI Escape
-Codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors) in Go (Golang). It
+Codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) in Go (Golang). It
 has support for Windows too! The API can be used in several ways, pick one that
 suits you.
 

--- a/vendor/github.com/mattn/go-isatty/isatty_solaris.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_solaris.go
@@ -8,7 +8,7 @@ import (
 )
 
 // IsTerminal returns true if the given file descriptor is a terminal.
-// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+// see: https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
 func IsTerminal(fd uintptr) bool {
 	var termio unix.Termio
 	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)

--- a/vendor/github.com/onsi/ginkgo/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/CHANGELOG.md
@@ -17,7 +17,7 @@ Improvements:
 
 - Significantly improved parallel test distribution.  Now instead of pre-sharding test cases across workers (which can result in idle workers and poor test performance) Ginkgo uses a shared queue to keep all workers busy until all tests are complete.  This improves test-time performance and consistency.
 - `Skip(message)` can be used to skip the current test.
-- Added `extensions/table` - a Ginkgo DSL for [Table Driven Tests](http://onsi.github.io/ginkgo/#table-driven-tests)
+- Added `extensions/table` - a Ginkgo DSL for [Table Driven Tests](https://onsi.github.io/ginkgo/#table-driven-tests)
 - Add `GinkgoRandomSeed()` - shorthand for `config.GinkgoConfig.RandomSeed`
 - Support for retrying flaky tests with `--flakeAttempts`
 - `ginkgo ./...` now recurses as you'd expect
@@ -64,7 +64,7 @@ Improvements:
     - `ginkgo build <path-to-package>` will now compile the package, producing a file named `package.test`
     - The compiled `package.test` file can be run directly.  This runs the tests in series.
     - To run precompiled tests in parallel, you can run: `ginkgo -p package.test`
-- Support `bootstrap`ping and `generate`ing [Agouti](http://agouti.org) specs.
+- Support `bootstrap`ping and `generate`ing [Agouti](https://agouti.org) specs.
 - `ginkgo generate` and `ginkgo bootstrap` now honor the package name already defined in a given directory
 - The `ginkgo` CLI ignores `SIGQUIT`.  Prevents its stack dump from interlacing with the underlying test suite's stack dump.
 - The `ginkgo` CLI now compiles tests into a temporary directory instead of the package directory.  This necessitates upgrading to Go v1.4+.

--- a/vendor/github.com/onsi/ginkgo/README.md
+++ b/vendor/github.com/onsi/ginkgo/README.md
@@ -1,29 +1,29 @@
-![Ginkgo: A Golang BDD Testing Framework](http://onsi.github.io/ginkgo/images/ginkgo.png)
+![Ginkgo: A Golang BDD Testing Framework](https://onsi.github.io/ginkgo/images/ginkgo.png)
 
 [![Build Status](https://travis-ci.org/onsi/ginkgo.svg)](https://travis-ci.org/onsi/ginkgo)
 
-Jump to the [docs](http://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
+Jump to the [docs](https://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
 
 If you have a question, comment, bug report, feature request, etc. please open a GitHub issue.
 
 ## Feature List
 
-- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](http://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](http://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
+- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](https://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](https://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
 
 - Structure your BDD-style tests expressively:
-    - Nestable [`Describe` and `Context` container blocks](http://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
-    - [`BeforeEach` and `AfterEach` blocks](http://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
-    - [`It` blocks](http://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
-    - [`JustBeforeEach` blocks](http://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
-    - [`BeforeSuite` and `AfterSuite` blocks](http://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
+    - Nestable [`Describe` and `Context` container blocks](https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
+    - [`BeforeEach` and `AfterEach` blocks](https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
+    - [`It` blocks](https://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
+    - [`JustBeforeEach` blocks](https://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
+    - [`BeforeSuite` and `AfterSuite` blocks](https://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
 
 - A comprehensive test runner that lets you:
-    - Mark specs as [pending](http://onsi.github.io/ginkgo/#pending-specs)
-    - [Focus](http://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
-    - Run your tests in [random order](http://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
-    - Break up your test suite into parallel processes for straightforward [test parallelization](http://onsi.github.io/ginkgo/#parallel-specs)
+    - Mark specs as [pending](https://onsi.github.io/ginkgo/#pending-specs)
+    - [Focus](https://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
+    - Run your tests in [random order](https://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
+    - Break up your test suite into parallel processes for straightforward [test parallelization](https://onsi.github.io/ginkgo/#parallel-specs)
 
-- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](http://onsi.github.io/ginkgo/#running-tests) and [generating](http://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
+- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](https://onsi.github.io/ginkgo/#running-tests) and [generating](https://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
     - `ginkgo -nodes=N` runs your tests in `N` parallel processes and print out coherent output in realtime
     - `ginkgo -cover` runs your tests using Golang's code coverage tool
     - `ginkgo convert` converts an XUnit-style `testing` package to a Ginkgo-style package
@@ -37,27 +37,27 @@ If you have a question, comment, bug report, feature request, etc. please open a
 
 - `ginkgo watch` [watches](https://onsi.github.io/ginkgo/#watching-for-changes) packages *and their dependencies* for changes, then reruns tests.  Run tests immediately as you develop!
 
-- Built-in support for testing [asynchronicity](http://onsi.github.io/ginkgo/#asynchronous-tests)
+- Built-in support for testing [asynchronicity](https://onsi.github.io/ginkgo/#asynchronous-tests)
 
-- Built-in support for [benchmarking](http://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
+- Built-in support for [benchmarking](https://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
 
 - [Completions for Sublime Text](https://github.com/onsi/ginkgo-sublime-completions): just use [Package Control](https://sublime.wbond.net/) to install `Ginkgo Completions`.
 
 - [Completions for VSCode](https://github.com/onsi/vscode-ginkgo): just use VSCode's extension installer to install `vscode-ginkgo`.
 
-- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](http://onsi.github.io/ginkgo/#third-party-integrations) for details.
+- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](https://onsi.github.io/ginkgo/#third-party-integrations) for details.
 
 - A modular architecture that lets you easily:
-    - Write [custom reporters](http://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](http://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
-    - [Adapt an existing matcher library (or write your own!)](http://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
+    - Write [custom reporters](https://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](https://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
+    - [Adapt an existing matcher library (or write your own!)](https://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
 
-## [Gomega](http://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
+## [Gomega](https://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
 
-Ginkgo is best paired with Gomega.  Learn more about Gomega [here](http://onsi.github.io/gomega/)
+Ginkgo is best paired with Gomega.  Learn more about Gomega [here](https://onsi.github.io/gomega/)
 
-## [Agouti](http://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
+## [Agouti](https://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
 
-Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](http://agouti.org)
+Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](https://agouti.org)
 
 ## Set Me Up!
 
@@ -87,16 +87,16 @@ With that said, it's great to know what your options are :)
 
 ### What Golang gives you out of the box
 
-Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](http://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
+Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](https://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
 
 ### Matcher libraries for Golang's XUnit style tests
 
 A number of matcher libraries have been written to augment Go's built-in XUnit style tests.  Here are two that have gained traction:
 
 - [testify](https://github.com/stretchr/testify)
-- [gocheck](http://labix.org/gocheck)
+- [gocheck](https://labix.org/gocheck)
 
-You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](http://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
+You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](https://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
 
 ### BDD style testing frameworks
 

--- a/vendor/github.com/onsi/ginkgo/config/config.go
+++ b/vendor/github.com/onsi/ginkgo/config/config.go
@@ -1,7 +1,7 @@
 /*
 Ginkgo accepts a number of configuration options.
 
-These are documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+These are documented [here](https://onsi.github.io/ginkgo/#the_ginkgo_cli)
 
 You can also learn more via
 

--- a/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
@@ -1,11 +1,11 @@
 /*
 Ginkgo is a BDD-style testing framework for Golang
 
-The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo/
+The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/ginkgo/
 
-Ginkgo's preferred matcher library is [Gomega](http://github.com/onsi/gomega)
+Ginkgo's preferred matcher library is [Gomega](https://github.com/onsi/gomega)
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Ginkgo is MIT-Licensed
 */
@@ -181,7 +181,7 @@ func CurrentGinkgoTestDescription() GinkgoTestDescription {
 //The optional info argument is passed to the test reporter and can be used to
 // provide the measurement data to a custom reporter with context.
 //
-//See http://onsi.github.io/ginkgo/#benchmark_tests for more details
+//See https://onsi.github.io/ginkgo/#benchmark_tests for more details
 type Benchmarker interface {
 	Time(name string, body func(), info ...interface{}) (elapsedTime time.Duration)
 	RecordValue(name string, value float64, info ...interface{})
@@ -541,7 +541,7 @@ func BeforeEach(body interface{}, timeout ...float64) bool {
 }
 
 //JustBeforeEach blocks are run before It blocks but *after* all BeforeEach blocks.  For more details,
-//read the [documentation](http://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
+//read the [documentation](https://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
 //
 //Like It blocks, BeforeEach blocks can be made asynchronous by providing a body function that accepts
 //a Done channel

--- a/vendor/github.com/onsi/ginkgo/internal/remote/output_interceptor_unix.go
+++ b/vendor/github.com/onsi/ginkgo/internal/remote/output_interceptor_unix.go
@@ -33,7 +33,7 @@ func (interceptor *outputInterceptor) StartInterceptingOutput() error {
 	// Call a function in ./syscall_dup_*.go
 	// If building for everything other than linux_arm64,
 	// use a "normal" syscall.Dup2(oldfd, newfd) call. If building for linux_arm64 (which doesn't have syscall.Dup2)
-	// call syscall.Dup3(oldfd, newfd, 0). They are nearly identical, see: http://linux.die.net/man/2/dup3
+	// call syscall.Dup3(oldfd, newfd, 0). They are nearly identical, see: https://linux.die.net/man/2/dup3
 	syscallDup(int(interceptor.redirectFile.Fd()), 1)
 	syscallDup(int(interceptor.redirectFile.Fd()), 2)
 

--- a/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -3,7 +3,7 @@ Ginkgo's Default Reporter
 
 A number of command line flags are available to tweak Ginkgo's default output.
 
-These are documented [here](http://onsi.github.io/ginkgo/#running_tests)
+These are documented [here](https://onsi.github.io/ginkgo/#running_tests)
 */
 package reporters
 

--- a/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -2,7 +2,7 @@
 
 JUnit XML Reporter for Ginkgo
 
-For usage instructions: http://onsi.github.io/ginkgo/#generating_junit_xml_output
+For usage instructions: https://onsi.github.io/ginkgo/#generating_junit_xml_output
 
 */
 

--- a/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/isatty_solaris.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/isatty_solaris.go
@@ -8,7 +8,7 @@ import (
 )
 
 // IsTerminal returns true if the given file descriptor is a terminal.
-// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+// see: https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
 func IsTerminal(fd uintptr) bool {
 	var termio unix.Termio
 	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)

--- a/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -3,7 +3,7 @@
 TeamCity Reporter for Ginkgo
 
 Makes use of TeamCity's support for Service Messages
-http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
+https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
 */
 
 package reporters

--- a/vendor/github.com/onsi/gomega/README.md
+++ b/vendor/github.com/onsi/gomega/README.md
@@ -1,14 +1,14 @@
-![Gomega: Ginkgo's Preferred Matcher Library](http://onsi.github.io/gomega/images/gomega.png)
+![Gomega: Ginkgo's Preferred Matcher Library](https://onsi.github.io/gomega/images/gomega.png)
 
 [![Build Status](https://travis-ci.org/onsi/gomega.svg)](https://travis-ci.org/onsi/gomega)
 
-Jump straight to the [docs](http://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](http://onsi.github.io/gomega/#provided-matchers).
+Jump straight to the [docs](https://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](https://onsi.github.io/gomega/#provided-matchers).
 
 If you have a question, comment, bug report, feature request, etc. please open a GitHub issue.
 
-## [Ginkgo](http://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
+## [Ginkgo](https://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
 
-Learn more about Ginkgo [here](http://onsi.github.io/ginkgo/)
+Learn more about Ginkgo [here](https://onsi.github.io/ginkgo/)
 
 ## Community Matchers
 

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -1,13 +1,13 @@
 /*
 Gomega is the Ginkgo BDD-style testing framework's preferred matcher library.
 
-The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/gomega/
+The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/gomega/
 
-Gomega on Github: http://github.com/onsi/gomega
+Gomega on Github: https://github.com/onsi/gomega
 
-Learn more about Ginkgo online: http://onsi.github.io/ginkgo
+Learn more about Ginkgo online: https://onsi.github.io/ginkgo
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Gomega is MIT-Licensed
 */

--- a/vendor/github.com/onsi/gomega/matchers/type_support.go
+++ b/vendor/github.com/onsi/gomega/matchers/type_support.go
@@ -4,7 +4,7 @@ Gomega matchers
 This package implements the Gomega matchers and does not typically need to be imported.
 See the docs for Gomega for documentation on the matchers
 
-http://onsi.github.io/gomega/
+https://onsi.github.io/gomega/
 */
 package matchers
 

--- a/vendor/github.com/onsi/gomega/types/types.go
+++ b/vendor/github.com/onsi/gomega/types/types.go
@@ -9,7 +9,7 @@ type GomegaTestingT interface {
 
 //All Gomega matchers must implement the GomegaMatcher interface
 //
-//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding_your_own_matchers
+//For details on writing custom matchers, check out: https://onsi.github.io/gomega/#adding_your_own_matchers
 type GomegaMatcher interface {
 	Match(actual interface{}) (success bool, err error)
 	FailureMessage(actual interface{}) (message string)

--- a/vendor/golang.org/x/net/html/charset/charset.go
+++ b/vendor/golang.org/x/net/html/charset/charset.go
@@ -48,7 +48,7 @@ func (h *htmlEncoding) NewEncoder() *encoding.Encoder {
 // DetermineEncoding determines the encoding of an HTML document by examining
 // up to the first 1024 bytes of content and the declared Content-Type.
 //
-// See http://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#determining-the-character-encoding
+// See https://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#determining-the-character-encoding
 func DetermineEncoding(content []byte, contentType string) (e encoding.Encoding, name string, certain bool) {
 	if len(content) > 1024 {
 		content = content[:1024]

--- a/vendor/golang.org/x/net/html/doctype.go
+++ b/vendor/golang.org/x/net/html/doctype.go
@@ -87,7 +87,7 @@ func parseDoctype(s string) (n *Node, quirks bool) {
 			}
 		}
 		if lastAttr := n.Attr[len(n.Attr)-1]; lastAttr.Key == "system" &&
-			strings.ToLower(lastAttr.Val) == "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd" {
+			strings.ToLower(lastAttr.Val) == "https://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd" {
 			quirks = true
 		}
 	}

--- a/vendor/golang.org/x/text/encoding/charmap/maketables.go
+++ b/vendor/golang.org/x/text/encoding/charmap/maketables.go
@@ -119,7 +119,7 @@ var encodings = []struct {
 		"",
 		"CodePage866",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-ibm866.txt",
+		"https://encoding.spec.whatwg.org/index-ibm866.txt",
 	},
 	{
 		"IBM Code Page 1047",
@@ -151,7 +151,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_2",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-2.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-2.txt",
 	},
 	{
 		"ISO 8859-3",
@@ -159,7 +159,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_3",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-3.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-3.txt",
 	},
 	{
 		"ISO 8859-4",
@@ -167,7 +167,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_4",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-4.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-4.txt",
 	},
 	{
 		"ISO 8859-5",
@@ -175,7 +175,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_5",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-5.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-5.txt",
 	},
 	{
 		"ISO 8859-6",
@@ -183,7 +183,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_6,ISO8859_6E,ISO8859_6I",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-6.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-6.txt",
 	},
 	{
 		"ISO 8859-7",
@@ -191,7 +191,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_7",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-7.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-7.txt",
 	},
 	{
 		"ISO 8859-8",
@@ -199,7 +199,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_8,ISO8859_8E,ISO8859_8I",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-8.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-8.txt",
 	},
 	{
 		"ISO 8859-9",
@@ -215,7 +215,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_10",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-10.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-10.txt",
 	},
 	{
 		"ISO 8859-13",
@@ -223,7 +223,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_13",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-13.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-13.txt",
 	},
 	{
 		"ISO 8859-14",
@@ -231,7 +231,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_14",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-14.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-14.txt",
 	},
 	{
 		"ISO 8859-15",
@@ -239,7 +239,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_15",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-15.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-15.txt",
 	},
 	{
 		"ISO 8859-16",
@@ -247,7 +247,7 @@ var encodings = []struct {
 		"",
 		"ISO8859_16",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-iso-8859-16.txt",
+		"https://encoding.spec.whatwg.org/index-iso-8859-16.txt",
 	},
 	{
 		"KOI8-R",
@@ -255,7 +255,7 @@ var encodings = []struct {
 		"",
 		"KOI8R",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-koi8-r.txt",
+		"https://encoding.spec.whatwg.org/index-koi8-r.txt",
 	},
 	{
 		"KOI8-U",
@@ -263,7 +263,7 @@ var encodings = []struct {
 		"",
 		"KOI8U",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-koi8-u.txt",
+		"https://encoding.spec.whatwg.org/index-koi8-u.txt",
 	},
 	{
 		"Macintosh",
@@ -271,7 +271,7 @@ var encodings = []struct {
 		"",
 		"Macintosh",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-macintosh.txt",
+		"https://encoding.spec.whatwg.org/index-macintosh.txt",
 	},
 	{
 		"Macintosh Cyrillic",
@@ -279,7 +279,7 @@ var encodings = []struct {
 		"",
 		"MacintoshCyrillic",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-x-mac-cyrillic.txt",
+		"https://encoding.spec.whatwg.org/index-x-mac-cyrillic.txt",
 	},
 	{
 		"Windows 874",
@@ -287,7 +287,7 @@ var encodings = []struct {
 		"",
 		"Windows874",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-874.txt",
+		"https://encoding.spec.whatwg.org/index-windows-874.txt",
 	},
 	{
 		"Windows 1250",
@@ -295,7 +295,7 @@ var encodings = []struct {
 		"",
 		"Windows1250",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1250.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1250.txt",
 	},
 	{
 		"Windows 1251",
@@ -303,7 +303,7 @@ var encodings = []struct {
 		"",
 		"Windows1251",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1251.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1251.txt",
 	},
 	{
 		"Windows 1252",
@@ -311,7 +311,7 @@ var encodings = []struct {
 		"",
 		"Windows1252",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1252.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1252.txt",
 	},
 	{
 		"Windows 1253",
@@ -319,7 +319,7 @@ var encodings = []struct {
 		"",
 		"Windows1253",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1253.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1253.txt",
 	},
 	{
 		"Windows 1254",
@@ -327,7 +327,7 @@ var encodings = []struct {
 		"",
 		"Windows1254",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1254.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1254.txt",
 	},
 	{
 		"Windows 1255",
@@ -335,7 +335,7 @@ var encodings = []struct {
 		"",
 		"Windows1255",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1255.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1255.txt",
 	},
 	{
 		"Windows 1256",
@@ -343,7 +343,7 @@ var encodings = []struct {
 		"",
 		"Windows1256",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1256.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1256.txt",
 	},
 	{
 		"Windows 1257",
@@ -351,7 +351,7 @@ var encodings = []struct {
 		"",
 		"Windows1257",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1257.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1257.txt",
 	},
 	{
 		"Windows 1258",
@@ -359,12 +359,12 @@ var encodings = []struct {
 		"",
 		"Windows1258",
 		encoding.ASCIISub,
-		"http://encoding.spec.whatwg.org/index-windows-1258.txt",
+		"https://encoding.spec.whatwg.org/index-windows-1258.txt",
 	},
 	{
 		"X-User-Defined",
 		"XUserDefined",
-		"It is defined at http://encoding.spec.whatwg.org/#x-user-defined",
+		"It is defined at https://encoding.spec.whatwg.org/#x-user-defined",
 		"XUserDefined",
 		encoding.ASCIISub,
 		ascii +
@@ -475,7 +475,7 @@ func main() {
 		all = append(all, varNames...)
 		varName := varNames[0]
 		switch {
-		case strings.HasPrefix(e.mapping, "http://encoding.spec.whatwg.org/"):
+		case strings.HasPrefix(e.mapping, "https://encoding.spec.whatwg.org/"):
 			e.mapping = getWHATWG(e.mapping)
 		case strings.HasPrefix(e.mapping, "http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/"):
 			e.mapping = getUCM(e.mapping)

--- a/vendor/golang.org/x/text/encoding/charmap/tables.go
+++ b/vendor/golang.org/x/text/encoding/charmap/tables.go
@@ -7184,7 +7184,7 @@ var windows1258 = Charmap{
 
 // XUserDefined is the X-User-Defined encoding.
 //
-// It is defined at http://encoding.spec.whatwg.org/#x-user-defined
+// It is defined at https://encoding.spec.whatwg.org/#x-user-defined
 var XUserDefined *Charmap = &xUserDefined
 
 var xUserDefined = Charmap{

--- a/vendor/golang.org/x/text/encoding/encoding.go
+++ b/vendor/golang.org/x/text/encoding/encoding.go
@@ -124,7 +124,7 @@ func (e *Encoder) Writer(w io.Writer) io.Writer {
 }
 
 // ASCIISub is the ASCII substitute character, as recommended by
-// http://unicode.org/reports/tr36/#Text_Comparison
+// https://unicode.org/reports/tr36/#Text_Comparison
 const ASCIISub = '\x1a'
 
 // Nop is the nop encoding. Its transformed bytes are the same as the source
@@ -145,7 +145,7 @@ func (nop) NewEncoder() *Encoder {
 // the replacement encoding yields the same as the source bytes except that
 // invalid UTF-8 is converted to '\uFFFD'.
 //
-// It is defined at http://encoding.spec.whatwg.org/#replacement
+// It is defined at https://encoding.spec.whatwg.org/#replacement
 var Replacement Encoding = replacement{}
 
 type replacement struct{}

--- a/vendor/golang.org/x/text/encoding/htmlindex/htmlindex.go
+++ b/vendor/golang.org/x/text/encoding/htmlindex/htmlindex.go
@@ -5,7 +5,7 @@
 //go:generate go run gen.go
 
 // Package htmlindex maps character set encoding names to Encodings as
-// recommended by the W3C for use in HTML 5. See http://www.w3.org/TR/encoding.
+// recommended by the W3C for use in HTML 5. See https://www.w3.org/TR/encoding/.
 package htmlindex
 
 // TODO: perhaps have a "bare" version of the index (used by this package) that
@@ -57,7 +57,7 @@ func LanguageDefault(tag language.Tag) string {
 }
 
 // Get returns an Encoding for one of the names listed in
-// http://www.w3.org/TR/encoding using the Default Index. Matching is case-
+// https://www.w3.org/TR/encoding/ using the Default Index. Matching is case-
 // insensitive.
 func Get(name string) (encoding.Encoding, error) {
 	x, ok := nameMap[strings.ToLower(strings.TrimSpace(name))]

--- a/vendor/golang.org/x/text/encoding/internal/identifier/identifier.go
+++ b/vendor/golang.org/x/text/encoding/internal/identifier/identifier.go
@@ -31,11 +31,11 @@ package identifier
 
 // References:
 // - http://source.icu-project.org/repos/icu/icu/trunk/source/data/mappings/convrtrs.txt
-// - http://www.iana.org/assignments/character-sets/character-sets.xhtml
-// - http://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
-// - http://www.ietf.org/rfc/rfc2978.txt
+// - https://www.iana.org/assignments/character-sets/character-sets.xhtml
+// - https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
+// - https://www.ietf.org/rfc/rfc2978.txt
 // - http://www.unicode.org/reports/tr22/
-// - http://www.w3.org/TR/encoding/
+// - https://www.w3.org/TR/encoding/
 // - https://encoding.spec.whatwg.org/
 // - https://encoding.spec.whatwg.org/encodings.json
 // - https://tools.ietf.org/html/rfc6657#section-5
@@ -61,7 +61,7 @@ type Interface interface {
 // some identifiers for some encodings that are not covered by the IANA
 // standard.
 //
-// See http://www.iana.org/assignments/ianacharset-mib.
+// See https://www.iana.org/assignments/ianacharset-mib.
 type MIB uint16
 
 // These additional MIB types are not defined in IANA. They are added because

--- a/vendor/golang.org/x/text/encoding/internal/identifier/mib.go
+++ b/vendor/golang.org/x/text/encoding/internal/identifier/mib.go
@@ -732,18 +732,18 @@ const (
 
 	// ISO885913 is the MIB identifier with IANA name ISO-8859-13.
 	//
-	// ISO See http://www.iana.org/assignments/charset-reg/ISO-8859-13 http://www.iana.org/assignments/charset-reg/ISO-8859-13
+	// ISO See https://www.iana.org/assignments/charset-reg/ISO-8859-13 https://www.iana.org/assignments/charset-reg/ISO-8859-13
 	ISO885913 MIB = 109
 
 	// ISO885914 is the MIB identifier with IANA name ISO-8859-14.
 	//
-	// ISO See http://www.iana.org/assignments/charset-reg/ISO-8859-14
+	// ISO See https://www.iana.org/assignments/charset-reg/ISO-8859-14
 	ISO885914 MIB = 110
 
 	// ISO885915 is the MIB identifier with IANA name ISO-8859-15.
 	//
 	// ISO
-	// Please see: http://www.iana.org/assignments/charset-reg/ISO-8859-15
+	// Please see: https://www.iana.org/assignments/charset-reg/ISO-8859-15
 	ISO885915 MIB = 111
 
 	// ISO885916 is the MIB identifier with IANA name ISO-8859-16.
@@ -754,41 +754,41 @@ const (
 	// GBK is the MIB identifier with IANA name GBK.
 	//
 	// Chinese IT Standardization Technical Committee
-	// Please see: http://www.iana.org/assignments/charset-reg/GBK
+	// Please see: https://www.iana.org/assignments/charset-reg/GBK
 	GBK MIB = 113
 
 	// GB18030 is the MIB identifier with IANA name GB18030.
 	//
 	// Chinese IT Standardization Technical Committee
-	// Please see: http://www.iana.org/assignments/charset-reg/GB18030
+	// Please see: https://www.iana.org/assignments/charset-reg/GB18030
 	GB18030 MIB = 114
 
 	// OSDEBCDICDF0415 is the MIB identifier with IANA name OSD_EBCDIC_DF04_15.
 	//
 	// Fujitsu-Siemens standard mainframe EBCDIC encoding
-	// Please see: http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-15
+	// Please see: https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-15
 	OSDEBCDICDF0415 MIB = 115
 
 	// OSDEBCDICDF03IRV is the MIB identifier with IANA name OSD_EBCDIC_DF03_IRV.
 	//
 	// Fujitsu-Siemens standard mainframe EBCDIC encoding
-	// Please see: http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF03-IRV
+	// Please see: https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF03-IRV
 	OSDEBCDICDF03IRV MIB = 116
 
 	// OSDEBCDICDF041 is the MIB identifier with IANA name OSD_EBCDIC_DF04_1.
 	//
 	// Fujitsu-Siemens standard mainframe EBCDIC encoding
-	// Please see: http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-1
+	// Please see: https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-1
 	OSDEBCDICDF041 MIB = 117
 
 	// ISO115481 is the MIB identifier with IANA name ISO-11548-1.
 	//
-	// See http://www.iana.org/assignments/charset-reg/ISO-11548-1
+	// See https://www.iana.org/assignments/charset-reg/ISO-11548-1
 	ISO115481 MIB = 118
 
 	// KZ1048 is the MIB identifier with IANA name KZ-1048.
 	//
-	// See http://www.iana.org/assignments/charset-reg/KZ-1048
+	// See https://www.iana.org/assignments/charset-reg/KZ-1048
 	KZ1048 MIB = 119
 
 	// Unicode is the MIB identifier with IANA name ISO-10646-UCS-2.
@@ -855,7 +855,7 @@ const (
 
 	// SCSU is the MIB identifier with IANA name SCSU.
 	//
-	// SCSU See http://www.iana.org/assignments/charset-reg/SCSU
+	// SCSU See https://www.iana.org/assignments/charset-reg/SCSU
 	SCSU MIB = 1011
 
 	// UTF7 is the MIB identifier with IANA name UTF-7.
@@ -884,22 +884,22 @@ const (
 
 	// CESU8 is the MIB identifier with IANA name CESU-8.
 	//
-	// http://www.unicode.org/unicode/reports/tr26
+	// http://www.unicode.org/reports/tr26/
 	CESU8 MIB = 1016
 
 	// UTF32 is the MIB identifier with IANA name UTF-32.
 	//
-	// http://www.unicode.org/unicode/reports/tr19/
+	// http://www.unicode.org/reports/tr19/
 	UTF32 MIB = 1017
 
 	// UTF32BE is the MIB identifier with IANA name UTF-32BE.
 	//
-	// http://www.unicode.org/unicode/reports/tr19/
+	// http://www.unicode.org/reports/tr19/
 	UTF32BE MIB = 1018
 
 	// UTF32LE is the MIB identifier with IANA name UTF-32LE.
 	//
-	// http://www.unicode.org/unicode/reports/tr19/
+	// http://www.unicode.org/reports/tr19/
 	UTF32LE MIB = 1019
 
 	// BOCU1 is the MIB identifier with IANA name BOCU-1.
@@ -1461,152 +1461,152 @@ const (
 
 	// IBM00858 is the MIB identifier with IANA name IBM00858.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM00858
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM00858
 	IBM00858 MIB = 2089
 
 	// IBM00924 is the MIB identifier with IANA name IBM00924.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM00924
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM00924
 	IBM00924 MIB = 2090
 
 	// IBM01140 is the MIB identifier with IANA name IBM01140.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01140
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01140
 	IBM01140 MIB = 2091
 
 	// IBM01141 is the MIB identifier with IANA name IBM01141.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01141
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01141
 	IBM01141 MIB = 2092
 
 	// IBM01142 is the MIB identifier with IANA name IBM01142.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01142
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01142
 	IBM01142 MIB = 2093
 
 	// IBM01143 is the MIB identifier with IANA name IBM01143.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01143
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01143
 	IBM01143 MIB = 2094
 
 	// IBM01144 is the MIB identifier with IANA name IBM01144.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01144
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01144
 	IBM01144 MIB = 2095
 
 	// IBM01145 is the MIB identifier with IANA name IBM01145.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01145
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01145
 	IBM01145 MIB = 2096
 
 	// IBM01146 is the MIB identifier with IANA name IBM01146.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01146
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01146
 	IBM01146 MIB = 2097
 
 	// IBM01147 is the MIB identifier with IANA name IBM01147.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01147
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01147
 	IBM01147 MIB = 2098
 
 	// IBM01148 is the MIB identifier with IANA name IBM01148.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01148
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01148
 	IBM01148 MIB = 2099
 
 	// IBM01149 is the MIB identifier with IANA name IBM01149.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01149
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01149
 	IBM01149 MIB = 2100
 
 	// Big5HKSCS is the MIB identifier with IANA name Big5-HKSCS.
 	//
-	// See http://www.iana.org/assignments/charset-reg/Big5-HKSCS
+	// See https://www.iana.org/assignments/charset-reg/Big5-HKSCS
 	Big5HKSCS MIB = 2101
 
 	// IBM1047 is the MIB identifier with IANA name IBM1047.
 	//
-	// IBM1047 (EBCDIC Latin 1/Open Systems) http://www-1.ibm.com/servers/eserver/iseries/software/globalization/pdf/cp01047z.pdf
+	// IBM1047 (EBCDIC Latin 1/Open Systems) https://www-1.ibm.com/servers/eserver/iseries/software/globalization/pdf/cp01047z.pdf
 	IBM1047 MIB = 2102
 
 	// PTCP154 is the MIB identifier with IANA name PTCP154.
 	//
-	// See http://www.iana.org/assignments/charset-reg/PTCP154
+	// See https://www.iana.org/assignments/charset-reg/PTCP154
 	PTCP154 MIB = 2103
 
 	// Amiga1251 is the MIB identifier with IANA name Amiga-1251.
 	//
-	// See http://www.amiga.ultranet.ru/Amiga-1251.html
+	// See https://www.amiga.ultranet.ru/Amiga-1251.html
 	Amiga1251 MIB = 2104
 
 	// KOI7switched is the MIB identifier with IANA name KOI7-switched.
 	//
-	// See http://www.iana.org/assignments/charset-reg/KOI7-switched
+	// See https://www.iana.org/assignments/charset-reg/KOI7-switched
 	KOI7switched MIB = 2105
 
 	// BRF is the MIB identifier with IANA name BRF.
 	//
-	// See http://www.iana.org/assignments/charset-reg/BRF
+	// See https://www.iana.org/assignments/charset-reg/BRF
 	BRF MIB = 2106
 
 	// TSCII is the MIB identifier with IANA name TSCII.
 	//
-	// See http://www.iana.org/assignments/charset-reg/TSCII
+	// See https://www.iana.org/assignments/charset-reg/TSCII
 	TSCII MIB = 2107
 
 	// CP51932 is the MIB identifier with IANA name CP51932.
 	//
-	// See http://www.iana.org/assignments/charset-reg/CP51932
+	// See https://www.iana.org/assignments/charset-reg/CP51932
 	CP51932 MIB = 2108
 
 	// Windows874 is the MIB identifier with IANA name windows-874.
 	//
-	// See http://www.iana.org/assignments/charset-reg/windows-874
+	// See https://www.iana.org/assignments/charset-reg/windows-874
 	Windows874 MIB = 2109
 
 	// Windows1250 is the MIB identifier with IANA name windows-1250.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1250
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1250
 	Windows1250 MIB = 2250
 
 	// Windows1251 is the MIB identifier with IANA name windows-1251.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1251
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1251
 	Windows1251 MIB = 2251
 
 	// Windows1252 is the MIB identifier with IANA name windows-1252.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1252
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1252
 	Windows1252 MIB = 2252
 
 	// Windows1253 is the MIB identifier with IANA name windows-1253.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1253
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1253
 	Windows1253 MIB = 2253
 
 	// Windows1254 is the MIB identifier with IANA name windows-1254.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1254
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1254
 	Windows1254 MIB = 2254
 
 	// Windows1255 is the MIB identifier with IANA name windows-1255.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1255
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1255
 	Windows1255 MIB = 2255
 
 	// Windows1256 is the MIB identifier with IANA name windows-1256.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1256
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1256
 	Windows1256 MIB = 2256
 
 	// Windows1257 is the MIB identifier with IANA name windows-1257.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1257
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1257
 	Windows1257 MIB = 2257
 
 	// Windows1258 is the MIB identifier with IANA name windows-1258.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1258
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1258
 	Windows1258 MIB = 2258
 
 	// TIS620 is the MIB identifier with IANA name TIS-620.
@@ -1616,6 +1616,6 @@ const (
 
 	// CP50220 is the MIB identifier with IANA name CP50220.
 	//
-	// See http://www.iana.org/assignments/charset-reg/CP50220
+	// See https://www.iana.org/assignments/charset-reg/CP50220
 	CP50220 MIB = 2260
 )

--- a/vendor/golang.org/x/text/encoding/japanese/iso2022jp.go
+++ b/vendor/golang.org/x/text/encoding/japanese/iso2022jp.go
@@ -173,11 +173,11 @@ func (e *iso2022JPEncoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc in
 
 			// func init checks that the switch covers all tables.
 			//
-			// http://encoding.spec.whatwg.org/#iso-2022-jp says that "the index jis0212
+			// https://encoding.spec.whatwg.org/#iso-2022-jp says that "the index jis0212
 			// is not used by the iso-2022-jp encoder due to lack of widespread support".
 			//
 			// TODO: do we have to special-case U+00A5 and U+203E, as per
-			// http://encoding.spec.whatwg.org/#iso-2022-jp
+			// https://encoding.spec.whatwg.org/#iso-2022-jp
 			// Doing so would mean that "\u00a5" would not be preserved
 			// after an encode-decode round trip.
 			switch {

--- a/vendor/golang.org/x/text/encoding/japanese/maketables.go
+++ b/vendor/golang.org/x/text/encoding/japanese/maketables.go
@@ -40,8 +40,8 @@ func main() {
 		url  string
 		name string
 	}{
-		{"http://encoding.spec.whatwg.org/index-jis0208.txt", "0208"},
-		{"http://encoding.spec.whatwg.org/index-jis0212.txt", "0212"},
+		{"https://encoding.spec.whatwg.org/index-jis0208.txt", "0208"},
+		{"https://encoding.spec.whatwg.org/index-jis0212.txt", "0212"},
 	}
 	for i, table := range tables {
 		res, err := http.Get(table.url)

--- a/vendor/golang.org/x/text/encoding/japanese/tables.go
+++ b/vendor/golang.org/x/text/encoding/japanese/tables.go
@@ -4,7 +4,7 @@
 package japanese // import "golang.org/x/text/encoding/japanese"
 
 // jis0208Decode is the decoding table from JIS 0208 code to Unicode.
-// It is defined at http://encoding.spec.whatwg.org/index-jis0208.txt
+// It is defined at https://encoding.spec.whatwg.org/index-jis0208.txt
 var jis0208Decode = [...]uint16{
 	0:     0x3000,
 	1:     0x3001,
@@ -7733,7 +7733,7 @@ var jis0208Decode = [...]uint16{
 }
 
 // jis0212Decode is the decoding table from JIS 0212 code to Unicode.
-// It is defined at http://encoding.spec.whatwg.org/index-jis0212.txt
+// It is defined at https://encoding.spec.whatwg.org/index-jis0212.txt
 var jis0212Decode = [...]uint16{
 	108:  0x02D8,
 	109:  0x02C7,

--- a/vendor/golang.org/x/text/encoding/korean/maketables.go
+++ b/vendor/golang.org/x/text/encoding/korean/maketables.go
@@ -23,7 +23,7 @@ func main() {
 	fmt.Printf("// Package korean provides Korean encodings such as EUC-KR.\n")
 	fmt.Printf(`package korean // import "golang.org/x/text/encoding/korean"` + "\n\n")
 
-	res, err := http.Get("http://encoding.spec.whatwg.org/index-euc-kr.txt")
+	res, err := http.Get("https://encoding.spec.whatwg.org/index-euc-kr.txt")
 	if err != nil {
 		log.Fatalf("Get: %v", err)
 	}
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	fmt.Printf("// decode is the decoding table from EUC-KR code to Unicode.\n")
-	fmt.Printf("// It is defined at http://encoding.spec.whatwg.org/index-euc-kr.txt\n")
+	fmt.Printf("// It is defined at https://encoding.spec.whatwg.org/index-euc-kr.txt\n")
 	fmt.Printf("var decode = [...]uint16{\n")
 	for i, v := range mapping {
 		if v != 0 {

--- a/vendor/golang.org/x/text/encoding/korean/tables.go
+++ b/vendor/golang.org/x/text/encoding/korean/tables.go
@@ -4,7 +4,7 @@
 package korean // import "golang.org/x/text/encoding/korean"
 
 // decode is the decoding table from EUC-KR code to Unicode.
-// It is defined at http://encoding.spec.whatwg.org/index-euc-kr.txt
+// It is defined at https://encoding.spec.whatwg.org/index-euc-kr.txt
 var decode = [...]uint16{
 	0:     0xAC02,
 	1:     0xAC03,

--- a/vendor/golang.org/x/text/encoding/simplifiedchinese/gbk.go
+++ b/vendor/golang.org/x/text/encoding/simplifiedchinese/gbk.go
@@ -53,7 +53,7 @@ loop:
 			r, size = rune(c0), 1
 
 		// Microsoft's Code Page 936 extends GBK 1.0 to encode the euro sign U+20AC
-		// as 0x80. The HTML5 specification at http://encoding.spec.whatwg.org/#gbk
+		// as 0x80. The HTML5 specification at https://encoding.spec.whatwg.org/#gbk
 		// says to treat "gbk" as Code Page 936.
 		case c0 == 0x80:
 			r, size = '€', 1
@@ -178,7 +178,7 @@ func (e gbkEncoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err 
 				}
 			case encode1Low <= r && r < encode1High:
 				// Microsoft's Code Page 936 extends GBK 1.0 to encode the euro sign U+20AC
-				// as 0x80. The HTML5 specification at http://encoding.spec.whatwg.org/#gbk
+				// as 0x80. The HTML5 specification at https://encoding.spec.whatwg.org/#gbk
 				// says to treat "gbk" as Code Page 936.
 				if r == '€' {
 					r = 0x80

--- a/vendor/golang.org/x/text/encoding/simplifiedchinese/maketables.go
+++ b/vendor/golang.org/x/text/encoding/simplifiedchinese/maketables.go
@@ -28,13 +28,13 @@ func main() {
 }
 
 func printGB18030() {
-	res, err := http.Get("http://encoding.spec.whatwg.org/index-gb18030.txt")
+	res, err := http.Get("https://encoding.spec.whatwg.org/index-gb18030.txt")
 	if err != nil {
 		log.Fatalf("Get: %v", err)
 	}
 	defer res.Body.Close()
 
-	fmt.Printf("// gb18030 is the table from http://encoding.spec.whatwg.org/index-gb18030.txt\n")
+	fmt.Printf("// gb18030 is the table from https://encoding.spec.whatwg.org/index-gb18030.txt\n")
 	fmt.Printf("var gb18030 = [...][2]uint16{\n")
 	scanner := bufio.NewScanner(res.Body)
 	for scanner.Scan() {
@@ -54,7 +54,7 @@ func printGB18030() {
 }
 
 func printGBK() {
-	res, err := http.Get("http://encoding.spec.whatwg.org/index-gbk.txt")
+	res, err := http.Get("https://encoding.spec.whatwg.org/index-gbk.txt")
 	if err != nil {
 		log.Fatalf("Get: %v", err)
 	}
@@ -90,7 +90,7 @@ func printGBK() {
 	}
 
 	fmt.Printf("// decode is the decoding table from GBK code to Unicode.\n")
-	fmt.Printf("// It is defined at http://encoding.spec.whatwg.org/index-gbk.txt\n")
+	fmt.Printf("// It is defined at https://encoding.spec.whatwg.org/index-gbk.txt\n")
 	fmt.Printf("var decode = [...]uint16{\n")
 	for i, v := range mapping {
 		if v != 0 {

--- a/vendor/golang.org/x/text/encoding/simplifiedchinese/tables.go
+++ b/vendor/golang.org/x/text/encoding/simplifiedchinese/tables.go
@@ -3,7 +3,7 @@
 // Package simplifiedchinese provides Simplified Chinese encodings such as GBK.
 package simplifiedchinese // import "golang.org/x/text/encoding/simplifiedchinese"
 
-// gb18030 is the table from http://encoding.spec.whatwg.org/index-gb18030.txt
+// gb18030 is the table from https://encoding.spec.whatwg.org/index-gb18030.txt
 var gb18030 = [...][2]uint16{
 	{0x0000, 0x0080},
 	{0x0024, 0x00a5},
@@ -214,7 +214,7 @@ var gb18030 = [...][2]uint16{
 }
 
 // decode is the decoding table from GBK code to Unicode.
-// It is defined at http://encoding.spec.whatwg.org/index-gbk.txt
+// It is defined at https://encoding.spec.whatwg.org/index-gbk.txt
 var decode = [...]uint16{
 	0:     0x4E02,
 	1:     0x4E04,

--- a/vendor/golang.org/x/text/encoding/traditionalchinese/big5.go
+++ b/vendor/golang.org/x/text/encoding/traditionalchinese/big5.go
@@ -61,7 +61,7 @@ loop:
 			if i := int(c0-0x81)*157 + int(c1); i < len(decode) {
 				if 1133 <= i && i < 1167 {
 					// The two-rune special cases for LATIN CAPITAL / SMALL E WITH CIRCUMFLEX
-					// AND MACRON / CARON are from http://encoding.spec.whatwg.org/#big5
+					// AND MACRON / CARON are from https://encoding.spec.whatwg.org/#big5
 					switch i {
 					case 1133:
 						s = "\u00CA\u0304"

--- a/vendor/golang.org/x/text/encoding/traditionalchinese/maketables.go
+++ b/vendor/golang.org/x/text/encoding/traditionalchinese/maketables.go
@@ -23,7 +23,7 @@ func main() {
 	fmt.Printf("// Package traditionalchinese provides Traditional Chinese encodings such as Big5.\n")
 	fmt.Printf(`package traditionalchinese // import "golang.org/x/text/encoding/traditionalchinese"` + "\n\n")
 
-	res, err := http.Get("http://encoding.spec.whatwg.org/index-big5.txt")
+	res, err := http.Get("https://encoding.spec.whatwg.org/index-big5.txt")
 	if err != nil {
 		log.Fatalf("Get: %v", err)
 	}
@@ -47,13 +47,13 @@ func main() {
 		}
 		mapping[x] = y
 
-		// The WHATWG spec http://encoding.spec.whatwg.org/#indexes says that
+		// The WHATWG spec https://encoding.spec.whatwg.org/#indexes says that
 		// "The index pointer for code point in index is the first pointer
 		// corresponding to code point in index", which would normally mean
 		// that the code below should be guarded by "if reverse[y] == 0", but
 		// last instead of first seems to match the behavior of
 		// "iconv -f UTF-8 -t BIG5". For example, U+8005 者 occurs twice in
-		// http://encoding.spec.whatwg.org/index-big5.txt, as index 2148
+		// https://encoding.spec.whatwg.org/index-big5.txt, as index 2148
 		// (encoded as "\x8e\xcd") and index 6543 (encoded as "\xaa\xcc")
 		// and "echo 者 | iconv -f UTF-8 -t BIG5 | xxd" gives "\xaa\xcc".
 		c0, c1 := x/157, x%157
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	fmt.Printf("// decode is the decoding table from Big5 code to Unicode.\n")
-	fmt.Printf("// It is defined at http://encoding.spec.whatwg.org/index-big5.txt\n")
+	fmt.Printf("// It is defined at https://encoding.spec.whatwg.org/index-big5.txt\n")
 	fmt.Printf("var decode = [...]uint32{\n")
 	for i, v := range mapping {
 		if v != 0 {

--- a/vendor/golang.org/x/text/encoding/traditionalchinese/tables.go
+++ b/vendor/golang.org/x/text/encoding/traditionalchinese/tables.go
@@ -4,7 +4,7 @@
 package traditionalchinese // import "golang.org/x/text/encoding/traditionalchinese"
 
 // decode is the decoding table from Big5 code to Unicode.
-// It is defined at http://encoding.spec.whatwg.org/index-big5.txt
+// It is defined at https://encoding.spec.whatwg.org/index-big5.txt
 var decode = [...]uint32{
 	942:   0x000043F0,
 	943:   0x00004C32,

--- a/vendor/golang.org/x/text/encoding/unicode/override.go
+++ b/vendor/golang.org/x/text/encoding/unicode/override.go
@@ -19,7 +19,7 @@ import (
 // This technique is recommended by the W3C for use in HTML 5: "For
 // compatibility with deployed content, the byte order mark (also known as BOM)
 // is considered more authoritative than anything else."
-// http://www.w3.org/TR/encoding/#specification-hooks
+// https://www.w3.org/TR/encoding/#specification-hooks
 //
 // Using BOMOverride is mostly intended for use cases where the first characters
 // of a fallback encoding are known to not be a BOM, for example, for valid HTML

--- a/vendor/golang.org/x/text/language/doc.go
+++ b/vendor/golang.org/x/text/language/doc.go
@@ -94,7 +94,7 @@
 //
 // References
 //
-// BCP 47 - Tags for Identifying Languages http://tools.ietf.org/html/bcp47
+// BCP 47 - Tags for Identifying Languages https://tools.ietf.org/html/bcp47
 //
 package language // import "golang.org/x/text/language"
 

--- a/vendor/golang.org/x/text/language/gen.go
+++ b/vendor/golang.org/x/text/language/gen.go
@@ -291,7 +291,7 @@ func (ss *stringSet) join() string {
 
 // ianaEntry holds information for an entry in the IANA Language Subtag Repository.
 // All types use the same entry.
-// See http://tools.ietf.org/html/bcp47#section-5.1 for a description of the various
+// See https://tools.ietf.org/html/bcp47#section-5.1 for a description of the various
 // fields.
 type ianaEntry struct {
 	typ            string

--- a/vendor/golang.org/x/text/language/language.go
+++ b/vendor/golang.org/x/text/language/language.go
@@ -168,8 +168,8 @@ func (t Tag) canonicalize(c CanonType) (Tag, bool) {
 						// for legacy reasons, CLDR maps "no", the macro language
 						// code for Norwegian, to the dominant variant "nb". This
 						// change is currently under consideration for CLDR as well.
-						// See http://unicode.org/cldr/trac/ticket/2698 and also
-						// http://unicode.org/cldr/trac/ticket/1790 for some of the
+						// See https://unicode.org/cldr/trac/ticket/2698 and also
+						// https://unicode.org/cldr/trac/ticket/1790 for some of the
 						// practical implications. TODO: this check could be removed
 						// if CLDR adopts this change.
 						if c&CLDR == 0 || t.lang != _nb {
@@ -845,7 +845,7 @@ var errNoTLD = errors.New("language: region is not a valid ccTLD")
 // region will already be canonicalized it was obtained from a Tag that was
 // obtained using any of the default methods.
 func (r Region) TLD() (Region, error) {
-	// See http://en.wikipedia.org/wiki/Country_code_top-level_domain for the
+	// See https://en.wikipedia.org/wiki/Country_code_top-level_domain for the
 	// difference between ISO 3166-1 and IANA ccTLD.
 	if r.regionID == _GB {
 		r = Region{_UK}

--- a/vendor/golang.org/x/text/language/parse.go
+++ b/vendor/golang.org/x/text/language/parse.go
@@ -313,7 +313,7 @@ func parseTag(scan *scanner) (t Tag, end int) {
 	langStart := scan.start
 	end = scan.scan()
 	for len(scan.token) == 3 && isAlpha(scan.token[0]) {
-		// From http://tools.ietf.org/html/bcp47, <lang>-<extlang> tags are equivalent
+		// From https://tools.ietf.org/html/bcp47, <lang>-<extlang> tags are equivalent
 		// to a tag of the form <extlang>.
 		lang, e := getLangID(scan.token)
 		if lang != 0 {
@@ -766,7 +766,7 @@ func nextExtension(s string, p int) int {
 var errInvalidWeight = errors.New("ParseAcceptLanguage: invalid weight")
 
 // ParseAcceptLanguage parses the contents of an Accept-Language header as
-// defined in http://www.ietf.org/rfc/rfc2616.txt and returns a list of Tags and
+// defined in https://www.ietf.org/rfc/rfc2616.txt and returns a list of Tags and
 // a list of corresponding quality weights. It is more permissive than RFC 2616
 // and may return non-nil slices even if the input is not valid.
 // The Tags will be sorted by highest weight first and then by first occurrence.

--- a/vendor/gopkg.in/yaml.v2/README.md
+++ b/vendor/gopkg.in/yaml.v2/README.md
@@ -6,7 +6,7 @@ Introduction
 The yaml package enables Go programs to comfortably encode and decode YAML
 values. It was developed within [Canonical](https://www.canonical.com) as
 part of the [juju](https://juju.ubuntu.com) project, and is based on a
-pure Go port of the well-known [libyaml](http://pyyaml.org/wiki/LibYAML)
+pure Go port of the well-known [libyaml](https://pyyaml.org/wiki/LibYAML)
 C library to parse and generate YAML data quickly and reliably.
 
 Compatibility

--- a/vendor/gopkg.in/yaml.v2/encode.go
+++ b/vendor/gopkg.in/yaml.v2/encode.go
@@ -233,7 +233,7 @@ func isBase60Float(s string) (result bool) {
 	return base60float.MatchString(s)
 }
 
-// From http://yaml.org/type/float.html, except the regular expression there
+// From https://yaml.org/type/float.html, except the regular expression there
 // is bogus. In practice parsers do not enforce the "\.[0-9_]*" suffix.
 var base60float = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+(?:\.[0-9_]*)?$`)
 

--- a/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/vendor/gopkg.in/yaml.v2/readerc.go
@@ -149,7 +149,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 			switch parser.encoding {
 			case yaml_UTF8_ENCODING:
 				// Decode a UTF-8 character.  Check RFC 3629
-				// (http://www.ietf.org/rfc/rfc3629.txt) for more details.
+				// (https://www.ietf.org/rfc/rfc3629.txt) for more details.
 				//
 				// The following table (taken from the RFC) is used for
 				// decoding.
@@ -252,7 +252,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 
 				// The UTF-16 encoding is not as simple as one might
 				// naively think.  Check RFC 2781
-				// (http://www.ietf.org/rfc/rfc2781.txt).
+				// (https://www.ietf.org/rfc/rfc2781.txt).
 				//
 				// Normally, two subsequent bytes describe a Unicode
 				// character.  However a special technique (called a

--- a/vendor/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/gopkg.in/yaml.v2/scannerc.go
@@ -9,7 +9,7 @@ import (
 // ************
 //
 // The following notes assume that you are familiar with the YAML specification
-// (http://yaml.org/spec/1.2/spec.html).  We mostly follow it, although in
+// (https://yaml.org/spec/1.2/spec.html).  We mostly follow it, although in
 // some cases we are less restrictive that it requires.
 //
 // The process of transforming a YAML stream into a sequence of events is


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://man7.org/linux/man-pages/man1/keyctl.1.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man1/keyctl.1.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man2/keyctl.2.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man2/keyctl.2.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man3/keyctl_dh_compute.3.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man3/keyctl_dh_compute.3.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man3/keyctl_get_keyring_ID.3.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man3/keyctl_get_keyring_ID.3.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man3/keyctl_instantiate_iov.3.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man3/keyctl_instantiate_iov.3.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man3/keyctl_join_session_keyring.3.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man3/keyctl_join_session_keyring.3.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man3/keyctl_search.3.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man3/keyctl_search.3.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man3/keyctl_setperm.3.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man3/keyctl_setperm.3.html) result AnnotatedConnectException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/ (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM037-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM037-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM1047-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM1047-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM437-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM437-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM850-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM850-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM852-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM852-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM855-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM855-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM860-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM860-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM862-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM862-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM863-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM863-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM865-2.1.2.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/glibc-IBM865-2.1.2.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/ibm-1140_P100-1997.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/ibm-1140_P100-1997.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/iso-8859_1-1998.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/iso-8859_1-1998.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/iso-8859_9-1999.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/iso-8859_9-1999.ucm) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/windows-858-2000.ucm (200) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/data/trunk/charset/data/ucm/windows-858-2000.ucm) result SSLProtocolException).
* http://www.chronox.de/crypto-API/crypto/userspace-if.html (200) with 1 occurrences could not be migrated:  
   ([https](https://www.chronox.de/crypto-API/crypto/userspace-if.html) result SSLException).
* http://www.unicode.org/Public/UNIDATA/EmojiSources.txt (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/Public/UNIDATA/EmojiSources.txt) result SSLProtocolException).
* http://www.unicode.org/faq/emoji_dingbats.html (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/faq/emoji_dingbats.html) result SSLProtocolException).
* http://www.unicode.org/faq/utf_bom.html (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/faq/utf_bom.html) result SSLProtocolException).
* http://www.unicode.org/notes/tn6/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/notes/tn6/) result SSLProtocolException).
* http://www.unicode.org/reports/tr22/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/reports/tr22/) result SSLProtocolException).
* http://www.unicode.org/reports/tr24/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/reports/tr24/) result SSLProtocolException).
* http://www.unicode.org/reports/tr35/ (200) with 5 occurrences could not be migrated:  
   ([https](https://www.unicode.org/reports/tr35/) result SSLProtocolException).
* http://www.unicode.org/unicode/reports/tr19/ (301) with 3 occurrences could not be migrated:  
   ([https](https://www.unicode.org/unicode/reports/tr19/) result SSLProtocolException).
* http://www.unicode.org/unicode/reports/tr26 (301) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/unicode/reports/tr26) result SSLProtocolException).
* http://source.icu-project.org/repos/icu/icu/trunk/source/data/mappings/convrtrs.txt (404) with 1 occurrences could not be migrated:  
   ([https](https://source.icu-project.org/repos/icu/icu/trunk/source/data/mappings/convrtrs.txt) result SSLProtocolException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://host/path/file.extension (UnknownHostException) with 1 occurrences migrated to:  
  https://host/path/file.extension ([https](https://host/path/file.extension) result UnknownHostException).
* http://some/remote/file (UnknownHostException) with 3 occurrences migrated to:  
  https://some/remote/file ([https](https://some/remote/file) result UnknownHostException).
* http://url.1 (UnknownHostException) with 1 occurrences migrated to:  
  https://url.1 ([https](https://url.1) result UnknownHostException).
* http://url.2 (UnknownHostException) with 1 occurrences migrated to:  
  https://url.2 ([https](https://url.2) result UnknownHostException).
* http://www.amiga.ultranet.ru/Amiga-1251.html (UnknownHostException) with 1 occurrences migrated to:  
  https://www.amiga.ultranet.ru/Amiga-1251.html ([https](https://www.amiga.ultranet.ru/Amiga-1251.html) result UnknownHostException).
* http://encoding.spec.whatwg.org/index-gbk.txt (301) with 3 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-gbk.txt ([https](https://encoding.spec.whatwg.org/index-gbk.txt) result 410).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://agouti.org with 2 occurrences migrated to:  
  https://agouti.org ([https](https://agouti.org) result 200).
* http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity with 1 occurrences migrated to:  
  https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity ([https](https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity) result 200).
* http://en.wikipedia.org/wiki/ANSI_escape_code with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/ANSI_escape_code ([https](https://en.wikipedia.org/wiki/ANSI_escape_code) result 200).
* http://en.wikipedia.org/wiki/Country_code_top-level_domain with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Country_code_top-level_domain ([https](https://en.wikipedia.org/wiki/Country_code_top-level_domain) result 200).
* http://encoding.spec.whatwg.org/ with 10 occurrences migrated to:  
  https://encoding.spec.whatwg.org/ ([https](https://encoding.spec.whatwg.org/) result 200).
* http://encoding.spec.whatwg.org/index-big5.txt with 4 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-big5.txt ([https](https://encoding.spec.whatwg.org/index-big5.txt) result 200).
* http://encoding.spec.whatwg.org/index-euc-kr.txt with 3 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-euc-kr.txt ([https](https://encoding.spec.whatwg.org/index-euc-kr.txt) result 200).
* http://encoding.spec.whatwg.org/index-gb18030.txt with 3 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-gb18030.txt ([https](https://encoding.spec.whatwg.org/index-gb18030.txt) result 200).
* http://encoding.spec.whatwg.org/index-ibm866.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-ibm866.txt ([https](https://encoding.spec.whatwg.org/index-ibm866.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-10.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-10.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-10.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-13.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-13.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-13.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-14.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-14.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-14.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-15.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-15.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-15.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-16.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-16.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-16.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-2.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-2.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-2.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-3.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-3.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-3.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-4.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-4.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-4.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-5.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-5.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-5.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-6.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-6.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-6.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-7.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-7.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-7.txt) result 200).
* http://encoding.spec.whatwg.org/index-iso-8859-8.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-iso-8859-8.txt ([https](https://encoding.spec.whatwg.org/index-iso-8859-8.txt) result 200).
* http://encoding.spec.whatwg.org/index-jis0208.txt with 2 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-jis0208.txt ([https](https://encoding.spec.whatwg.org/index-jis0208.txt) result 200).
* http://encoding.spec.whatwg.org/index-jis0212.txt with 2 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-jis0212.txt ([https](https://encoding.spec.whatwg.org/index-jis0212.txt) result 200).
* http://encoding.spec.whatwg.org/index-koi8-r.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-koi8-r.txt ([https](https://encoding.spec.whatwg.org/index-koi8-r.txt) result 200).
* http://encoding.spec.whatwg.org/index-koi8-u.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-koi8-u.txt ([https](https://encoding.spec.whatwg.org/index-koi8-u.txt) result 200).
* http://encoding.spec.whatwg.org/index-macintosh.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-macintosh.txt ([https](https://encoding.spec.whatwg.org/index-macintosh.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1250.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1250.txt ([https](https://encoding.spec.whatwg.org/index-windows-1250.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1251.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1251.txt ([https](https://encoding.spec.whatwg.org/index-windows-1251.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1252.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1252.txt ([https](https://encoding.spec.whatwg.org/index-windows-1252.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1253.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1253.txt ([https](https://encoding.spec.whatwg.org/index-windows-1253.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1254.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1254.txt ([https](https://encoding.spec.whatwg.org/index-windows-1254.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1255.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1255.txt ([https](https://encoding.spec.whatwg.org/index-windows-1255.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1256.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1256.txt ([https](https://encoding.spec.whatwg.org/index-windows-1256.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1257.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1257.txt ([https](https://encoding.spec.whatwg.org/index-windows-1257.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-1258.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-1258.txt ([https](https://encoding.spec.whatwg.org/index-windows-1258.txt) result 200).
* http://encoding.spec.whatwg.org/index-windows-874.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-windows-874.txt ([https](https://encoding.spec.whatwg.org/index-windows-874.txt) result 200).
* http://encoding.spec.whatwg.org/index-x-mac-cyrillic.txt with 1 occurrences migrated to:  
  https://encoding.spec.whatwg.org/index-x-mac-cyrillic.txt ([https](https://encoding.spec.whatwg.org/index-x-mac-cyrillic.txt) result 200).
* http://example.com with 1 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* http://github.com/onsi/ginkgo with 3 occurrences migrated to:  
  https://github.com/onsi/ginkgo ([https](https://github.com/onsi/ginkgo) result 200).
* http://github.com/onsi/gomega with 3 occurrences migrated to:  
  https://github.com/onsi/gomega ([https](https://github.com/onsi/gomega) result 200).
* http://github.com/sclevine/agouti with 1 occurrences migrated to:  
  https://github.com/sclevine/agouti ([https](https://github.com/sclevine/agouti) result 200).
* http://labix.org/gocheck with 1 occurrences migrated to:  
  https://labix.org/gocheck ([https](https://labix.org/gocheck) result 200).
* http://linux.die.net/man/2/dup3 with 1 occurrences migrated to:  
  https://linux.die.net/man/2/dup3 ([https](https://linux.die.net/man/2/dup3) result 200).
* http://onsi.github.io/ginkgo/ with 28 occurrences migrated to:  
  https://onsi.github.io/ginkgo/ ([https](https://onsi.github.io/ginkgo/) result 200).
* http://onsi.github.io/ginkgo/images/ginkgo.png with 1 occurrences migrated to:  
  https://onsi.github.io/ginkgo/images/ginkgo.png ([https](https://onsi.github.io/ginkgo/images/ginkgo.png) result 200).
* http://onsi.github.io/gomega/ with 8 occurrences migrated to:  
  https://onsi.github.io/gomega/ ([https](https://onsi.github.io/gomega/) result 200).
* http://onsi.github.io/gomega/images/gomega.png with 1 occurrences migrated to:  
  https://onsi.github.io/gomega/images/gomega.png ([https](https://onsi.github.io/gomega/images/gomega.png) result 200).
* http://pyyaml.org/wiki/LibYAML with 1 occurrences migrated to:  
  https://pyyaml.org/wiki/LibYAML ([https](https://pyyaml.org/wiki/LibYAML) result 200).
* http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c with 2 occurrences migrated to:  
  https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c ([https](https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c) result 200).
* http://tools.ietf.org/html/bcp47 with 3 occurrences migrated to:  
  https://tools.ietf.org/html/bcp47 ([https](https://tools.ietf.org/html/bcp47) result 200).
* http://unicode.org/cldr/trac/ticket/1790 with 1 occurrences migrated to:  
  https://unicode.org/cldr/trac/ticket/1790 ([https](https://unicode.org/cldr/trac/ticket/1790) result 200).
* http://unicode.org/cldr/trac/ticket/2698 with 1 occurrences migrated to:  
  https://unicode.org/cldr/trac/ticket/2698 ([https](https://unicode.org/cldr/trac/ticket/2698) result 200).
* http://unicode.org/reports/tr36/ with 1 occurrences migrated to:  
  https://unicode.org/reports/tr36/ ([https](https://unicode.org/reports/tr36/) result 200).
* http://www.iana.org/assignments/character-sets/character-sets.xhtml with 1 occurrences migrated to:  
  https://www.iana.org/assignments/character-sets/character-sets.xhtml ([https](https://www.iana.org/assignments/character-sets/character-sets.xhtml) result 200).
* http://www.iana.org/assignments/charset-reg/BRF with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/BRF ([https](https://www.iana.org/assignments/charset-reg/BRF) result 200).
* http://www.iana.org/assignments/charset-reg/Big5-HKSCS with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/Big5-HKSCS ([https](https://www.iana.org/assignments/charset-reg/Big5-HKSCS) result 200).
* http://www.iana.org/assignments/charset-reg/CP50220 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/CP50220 ([https](https://www.iana.org/assignments/charset-reg/CP50220) result 200).
* http://www.iana.org/assignments/charset-reg/CP51932 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/CP51932 ([https](https://www.iana.org/assignments/charset-reg/CP51932) result 200).
* http://www.iana.org/assignments/charset-reg/GB18030 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/GB18030 ([https](https://www.iana.org/assignments/charset-reg/GB18030) result 200).
* http://www.iana.org/assignments/charset-reg/GBK with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/GBK ([https](https://www.iana.org/assignments/charset-reg/GBK) result 200).
* http://www.iana.org/assignments/charset-reg/IBM00858 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM00858 ([https](https://www.iana.org/assignments/charset-reg/IBM00858) result 200).
* http://www.iana.org/assignments/charset-reg/IBM00924 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM00924 ([https](https://www.iana.org/assignments/charset-reg/IBM00924) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01140 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01140 ([https](https://www.iana.org/assignments/charset-reg/IBM01140) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01141 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01141 ([https](https://www.iana.org/assignments/charset-reg/IBM01141) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01142 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01142 ([https](https://www.iana.org/assignments/charset-reg/IBM01142) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01143 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01143 ([https](https://www.iana.org/assignments/charset-reg/IBM01143) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01144 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01144 ([https](https://www.iana.org/assignments/charset-reg/IBM01144) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01145 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01145 ([https](https://www.iana.org/assignments/charset-reg/IBM01145) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01146 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01146 ([https](https://www.iana.org/assignments/charset-reg/IBM01146) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01147 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01147 ([https](https://www.iana.org/assignments/charset-reg/IBM01147) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01148 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01148 ([https](https://www.iana.org/assignments/charset-reg/IBM01148) result 200).
* http://www.iana.org/assignments/charset-reg/IBM01149 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/IBM01149 ([https](https://www.iana.org/assignments/charset-reg/IBM01149) result 200).
* http://www.iana.org/assignments/charset-reg/ISO-11548-1 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/ISO-11548-1 ([https](https://www.iana.org/assignments/charset-reg/ISO-11548-1) result 200).
* http://www.iana.org/assignments/charset-reg/ISO-8859-13 with 2 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/ISO-8859-13 ([https](https://www.iana.org/assignments/charset-reg/ISO-8859-13) result 200).
* http://www.iana.org/assignments/charset-reg/ISO-8859-14 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/ISO-8859-14 ([https](https://www.iana.org/assignments/charset-reg/ISO-8859-14) result 200).
* http://www.iana.org/assignments/charset-reg/ISO-8859-15 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/ISO-8859-15 ([https](https://www.iana.org/assignments/charset-reg/ISO-8859-15) result 200).
* http://www.iana.org/assignments/charset-reg/KOI7-switched with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/KOI7-switched ([https](https://www.iana.org/assignments/charset-reg/KOI7-switched) result 200).
* http://www.iana.org/assignments/charset-reg/KZ-1048 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/KZ-1048 ([https](https://www.iana.org/assignments/charset-reg/KZ-1048) result 200).
* http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF03-IRV with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF03-IRV ([https](https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF03-IRV) result 200).
* http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-1 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-1 ([https](https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-1) result 200).
* http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-15 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-15 ([https](https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-15) result 200).
* http://www.iana.org/assignments/charset-reg/PTCP154 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/PTCP154 ([https](https://www.iana.org/assignments/charset-reg/PTCP154) result 200).
* http://www.iana.org/assignments/charset-reg/SCSU with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/SCSU ([https](https://www.iana.org/assignments/charset-reg/SCSU) result 200).
* http://www.iana.org/assignments/charset-reg/TSCII with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/TSCII ([https](https://www.iana.org/assignments/charset-reg/TSCII) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1250 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1250 ([https](https://www.iana.org/assignments/charset-reg/windows-1250) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1251 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1251 ([https](https://www.iana.org/assignments/charset-reg/windows-1251) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1252 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1252 ([https](https://www.iana.org/assignments/charset-reg/windows-1252) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1253 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1253 ([https](https://www.iana.org/assignments/charset-reg/windows-1253) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1254 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1254 ([https](https://www.iana.org/assignments/charset-reg/windows-1254) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1255 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1255 ([https](https://www.iana.org/assignments/charset-reg/windows-1255) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1256 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1256 ([https](https://www.iana.org/assignments/charset-reg/windows-1256) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1257 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1257 ([https](https://www.iana.org/assignments/charset-reg/windows-1257) result 200).
* http://www.iana.org/assignments/charset-reg/windows-1258 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-1258 ([https](https://www.iana.org/assignments/charset-reg/windows-1258) result 200).
* http://www.iana.org/assignments/charset-reg/windows-874 with 1 occurrences migrated to:  
  https://www.iana.org/assignments/charset-reg/windows-874 ([https](https://www.iana.org/assignments/charset-reg/windows-874) result 200).
* http://www.iana.org/assignments/ianacharset-mib/ianacharset-mib with 1 occurrences migrated to:  
  https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib ([https](https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib) result 200).
* http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd with 1 occurrences migrated to:  
  https://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd ([https](https://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd) result 200).
* http://www.ietf.org/rfc/rfc2616.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2616.txt ([https](https://www.ietf.org/rfc/rfc2616.txt) result 200).
* http://www.ietf.org/rfc/rfc2781.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2781.txt ([https](https://www.ietf.org/rfc/rfc2781.txt) result 200).
* http://www.ietf.org/rfc/rfc2978.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2978.txt ([https](https://www.ietf.org/rfc/rfc2978.txt) result 200).
* http://www.ietf.org/rfc/rfc3629.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc3629.txt ([https](https://www.ietf.org/rfc/rfc3629.txt) result 200).
* http://www.w3.org/TR/encoding/ with 2 occurrences migrated to:  
  https://www.w3.org/TR/encoding/ ([https](https://www.w3.org/TR/encoding/) result 200).
* http://www.w3.org/TR/encoding (301) with 2 occurrences migrated to:  
  https://www.w3.org/TR/encoding/ ([https](https://www.w3.org/TR/encoding) result 200).
* http://yaml.org/spec/1.2/spec.html with 1 occurrences migrated to:  
  https://yaml.org/spec/1.2/spec.html ([https](https://yaml.org/spec/1.2/spec.html) result 200).
* http://yaml.org/type/float.html with 1 occurrences migrated to:  
  https://yaml.org/type/float.html ([https](https://yaml.org/type/float.html) result 200).
* http://golang.org/pkg/testing with 1 occurrences migrated to:  
  https://golang.org/pkg/testing ([https](https://golang.org/pkg/testing) result 301).
* http://onsi.github.io/ginkgo with 1 occurrences migrated to:  
  https://onsi.github.io/ginkgo ([https](https://onsi.github.io/ginkgo) result 301).
* http://www-1.ibm.com/servers/eserver/iseries/software/globalization/pdf/cp01047z.pdf with 1 occurrences migrated to:  
  https://www-1.ibm.com/servers/eserver/iseries/software/globalization/pdf/cp01047z.pdf ([https](https://www-1.ibm.com/servers/eserver/iseries/software/globalization/pdf/cp01047z.pdf) result 301).
* http://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html with 1 occurrences migrated to:  
  https://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html ([https](https://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html) result 301).
* http://www.iana.org/assignments/ianacharset-mib with 1 occurrences migrated to:  
  https://www.iana.org/assignments/ianacharset-mib ([https](https://www.iana.org/assignments/ianacharset-mib) result 302).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/1998/Math/MathML with 1 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences
* http://www.w3.org/2000/svg with 1 occurrences
* http://www.w3.org/TR/html4/sgml/entities.html with 1 occurrences