### PR TITLE
Improve error handling and properly parse URL on Windows

### DIFF
--- a/download/cache/cache.go
+++ b/download/cache/cache.go
@@ -185,6 +185,9 @@ func writeDataToNamedFile(data io.ReadCloser, filePath string) error {
 
 func fileExists(filePath string) bool {
 	fi, err := os.Stat(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return false
+	}
 	if os.IsNotExist(err) || fi.IsDir() {
 		return false
 	}
@@ -196,7 +199,7 @@ func createDownloadsDirectory(dirPath string) error {
 }
 
 func createFilePathForDownloadFile(url string, destinationDirectory string) string {
-	tokens := strings.Split(url, string(os.PathSeparator))
+	tokens := strings.Split(url, "/")
 	fileName := tokens[len(tokens)-1]
 	filePath := path.Join(destinationDirectory, fileName)
 	return filePath


### PR DESCRIPTION
Two bug fixes:

1. Properly handle the case when there is an error calling `os.Stat` and it's not a error because the file doesn't exist (it may be good to log this error some how, but I'm not sure the best way to do that so I left it out).

2. Properly parse the URL on Windows. On Windows, `os.PathSeparator` will be `\`. There are no `\` characters in a URL, so parsing would fail and the created path would be weird and contain invalid characters on Windows. This will parse always using a `/`, so it should work on both Unix & Windows.