### PR TITLE
Fixes another Windows compatibility issue

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -109,7 +109,9 @@ type httpHelper struct {
 }
 
 func (h *httpHelper) CreateHttpRequest(method string, url string) (HttpRequest, error) {
+	tr := &http.Transport{Proxy: http.ProxyFromEnvironment}
 	cl := &http.Client{
+		Transport:     tr,
 		CheckRedirect: nil,
 	}
 

--- a/java/run_shell.go
+++ b/java/run_shell.go
@@ -24,7 +24,7 @@ import (
 )
 
 func RunShell(cmd *exec.Cmd) error {
-	cmd.Env = envVars("PATH", "HOME", "CF_HOME")
+	cmd.Env = envVars("PATH", "HOME", "CF_HOME", "HOMEDRIVE", "HOMEPATH", "TMP", "TEMP")
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/plugin.go
+++ b/plugin.go
@@ -56,6 +56,7 @@ func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSslValidation},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	client := &http.Client{
 		Transport: tr,


### PR DESCRIPTION
TMP/TEMP seem to be required by Spring Boot, or you end up with required Windows specific dependencies not being on the classpath. HOMEDRIVE and HOMEPATH are needed as that is how the cf cli finds CF_HOME on Windows.